### PR TITLE
Phantom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ keywords = ["ceph"]
 license = "MIT"
 name = "ceph-rbd"
 repository = "https://github.com/cholcombe973/ceph-rbd"
-version = "0.3.0"
+version = "0.2.2"
 
 [build-dependencies]
 bindgen = "0.36.0"
 
 [dependencies]
-ceph = "~0.6"
+ceph = { git="https://github.com/ceph/ceph-rust", branch="phantom"}
 libc = "~0.2"
 log = "~0.4"
 nix = "~0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.2.2"
 bindgen = "0.36.0"
 
 [dependencies]
-ceph = { git="https://github.com/ceph/ceph-rust", branch="phantom"}
+ceph = "~1.0"
 libc = "~0.2"
 log = "~0.4"
 nix = "~0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ keywords = ["ceph"]
 license = "MIT"
 name = "ceph-rbd"
 repository = "https://github.com/cholcombe973/ceph-rbd"
-version = "0.2.2"
+version = "0.3.0"
 
 [build-dependencies]
 bindgen = "0.36.0"
 
 [dependencies]
-ceph = "~0.5"
+ceph = "~0.6"
 libc = "~0.2"
 log = "~0.4"
 nix = "~0.10"

--- a/src/rbd.rs
+++ b/src/rbd.rs
@@ -122,7 +122,7 @@ impl Rbd {
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
-            let ret_code = rbd_create4(ioctx.ioctx, name.as_ptr(), size, opts);
+            let ret_code = rbd_create4(*ioctx.inner(), name.as_ptr(), size, opts);
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -191,10 +191,10 @@ impl Rbd {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
             let ret_code = rbd_clone3(
-                parent_ioctx.ioctx,
+                *parent_ioctx.inner(),
                 parent_name.as_ptr(),
                 parent_snapname.as_ptr(),
-                ioctx.ioctx,
+                *ioctx.inner(),
                 name.as_ptr(),
                 opts,
             );
@@ -216,7 +216,7 @@ impl Rbd {
     pub fn remove(&self, ioctx: &IoCtx, name: &str) -> RadosResult<()> {
         let name = CString::new(name)?;
         unsafe {
-            let ret_code = rbd_remove(ioctx.ioctx, name.as_ptr());
+            let ret_code = rbd_remove(*ioctx.inner(), name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -229,7 +229,7 @@ impl Rbd {
         let src = CString::new(src)?;
         let dst = CString::new(dst)?;
         unsafe {
-            let ret_code = rbd_rename(ioctx.ioctx, src.as_ptr(), dst.as_ptr());
+            let ret_code = rbd_rename(*ioctx.inner(), src.as_ptr(), dst.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -240,7 +240,7 @@ impl Rbd {
     pub fn mirror_mode_get(self, ioctx: &IoCtx) -> RadosResult<rbd_mirror_mode_t> {
         let mut mode = rbd_mirror_mode_t_RBD_MIRROR_MODE_DISABLED;
         unsafe {
-            let ret_code = rbd_mirror_mode_get(ioctx.ioctx, &mut mode);
+            let ret_code = rbd_mirror_mode_get(*ioctx.inner(), &mut mode);
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -252,7 +252,7 @@ impl Rbd {
     ///Set pool mirror mode.
     pub fn mirror_mode_set(self, ioctx: &IoCtx, mirror_mode: rbd_mirror_mode_t) -> RadosResult<()> {
         unsafe {
-            let ret_code = rbd_mirror_mode_set(ioctx.ioctx, mirror_mode);
+            let ret_code = rbd_mirror_mode_set(*ioctx.inner(), mirror_mode);
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -273,7 +273,7 @@ impl Rbd {
         let mut uuid: Vec<i8> = Vec::with_capacity(512);
         unsafe {
             let ret_code = rbd_mirror_peer_add(
-                ioctx.ioctx,
+                *ioctx.inner(),
                 uuid.as_mut_ptr(),
                 uuid.capacity(),
                 cluster_name.as_ptr(),
@@ -291,7 +291,7 @@ impl Rbd {
     pub fn mirror_peer_remove(self, ioctx: &IoCtx, uuid: &str) -> RadosResult<()> {
         let uuid = CString::new(uuid)?;
         unsafe {
-            let ret_code = rbd_mirror_peer_remove(ioctx.ioctx, uuid.as_ptr());
+            let ret_code = rbd_mirror_peer_remove(*ioctx.inner(), uuid.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -310,7 +310,7 @@ impl Rbd {
         let client_name = CString::new(client_name)?;
         unsafe {
             let ret_code =
-                rbd_mirror_peer_set_client(ioctx.ioctx, uuid.as_ptr(), client_name.as_ptr());
+                rbd_mirror_peer_set_client(*ioctx.inner(), uuid.as_ptr(), client_name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -329,7 +329,7 @@ impl Rbd {
         let cluster_name = CString::new(cluster_name)?;
         unsafe {
             let ret_code =
-                rbd_mirror_peer_set_cluster(ioctx.ioctx, uuid.as_ptr(), cluster_name.as_ptr());
+                rbd_mirror_peer_set_cluster(*ioctx.inner(), uuid.as_ptr(), cluster_name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -412,7 +412,7 @@ impl Rbd {
         let mut name_size: usize = name_buff.capacity();
         loop {
             unsafe {
-                let retcode = rbd_list(ioctx.ioctx, name_buff.as_mut_ptr(), &mut name_size);
+                let retcode = rbd_list(*ioctx.inner(), name_buff.as_mut_ptr(), &mut name_size);
                 if retcode == -(nix::errno::Errno::ERANGE as i32) {
                     // provided byte array is smaller than listing size
                     trace!("Resizing to {}", name_size + 1);
@@ -551,7 +551,7 @@ impl<'a> RbdImage<'a> {
         let mut rbd: rbd_image_t = ptr::null_mut();
 
         unsafe {
-            let ret_code = rbd_open(ioctx.ioctx, name.as_ptr(), &mut rbd, snap_name.as_ptr());
+            let ret_code = rbd_open(*ioctx.inner(), name.as_ptr(), &mut rbd, snap_name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -602,7 +602,7 @@ pub fn aio_open_by_id(){
 
         unsafe {
             let ret_code =
-                rbd_open_read_only(ioctx.ioctx, name.as_ptr(), &mut rbd, snap_name.as_ptr());
+                rbd_open_read_only(*ioctx.inner(), name.as_ptr(), &mut rbd, snap_name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -890,7 +890,7 @@ pub fn resize2(){
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
-            let ret_code = rbd_copy3(self.image, dest_ioctx.ioctx, dest_name.as_ptr(), opts);
+            let ret_code = rbd_copy3(self.image, *dest_ioctx.inner(), dest_name.as_ptr(), opts);
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }

--- a/src/rbd.rs
+++ b/src/rbd.rs
@@ -56,7 +56,7 @@ pub struct RbdImageInfo {
     pub parent_pool: i64,
     pub parent_name: Option<String>,
 }
-
+ 
 impl Rbd {
     /// Create an rbd image
     /// name: what the image is called

--- a/src/rbd.rs
+++ b/src/rbd.rs
@@ -4,7 +4,9 @@ extern crate ceph;
 extern crate log;
 extern crate nix;
 
+use self::ceph::ceph::IoCtx;
 use self::ceph::error::{RadosError, RadosResult};
+
 use ffi::*;
 use get_error;
 
@@ -22,12 +24,13 @@ pub struct Rbd;
 #[derive(Debug)]
 pub struct RbdImage<'a> {
     image: rbd_image_t,
-    phantom: PhantomData<&'a rados_ioctx_t>,
+    phantom: PhantomData<&'a IoCtx>,
 }
 
 impl<'a> Drop for RbdImage<'a> {
     fn drop(&mut self) {
         if !self.image.is_null() {
+            println!("destroy rbd image");
             unsafe {
                 let retcode = rbd_close(self.image);
                 if retcode < 0 {
@@ -68,7 +71,7 @@ impl Rbd {
     /// data_pool: optional separate pool for data blocks
     pub fn create(
         &self,
-        ioctx: rados_ioctx_t,
+        ioctx: &IoCtx,
         name: &str,
         size: u64,
         order: Option<u64>,
@@ -119,7 +122,7 @@ impl Rbd {
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
-            let ret_code = rbd_create4(ioctx, name.as_ptr(), size, opts);
+            let ret_code = rbd_create4(ioctx.ioctx, name.as_ptr(), size, opts);
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -131,10 +134,10 @@ impl Rbd {
     /// Clone a parent rbd snapshot into a COW sparse child.
     pub fn clone(
         self,
-        parent_ioctx: rados_ioctx_t,
+        parent_ioctx: &IoCtx,
         parent_name: &str,
         parent_snapname: &str,
-        ioctx: rados_ioctx_t,
+        ioctx: &IoCtx,
         name: &str,
         features: Option<u64>,
         order: Option<u64>,
@@ -188,10 +191,10 @@ impl Rbd {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
             let ret_code = rbd_clone3(
-                parent_ioctx,
+                parent_ioctx.ioctx,
                 parent_name.as_ptr(),
                 parent_snapname.as_ptr(),
-                ioctx,
+                ioctx.ioctx,
                 name.as_ptr(),
                 opts,
             );
@@ -210,10 +213,10 @@ impl Rbd {
     ///not return until every object that comprises the image has
     ///been deleted. Note that all snapshots must be deleted before
     ///the image can be removed.
-    pub fn remove(&self, ioctx: rados_ioctx_t, name: &str) -> RadosResult<()> {
+    pub fn remove(&self, ioctx: &IoCtx, name: &str) -> RadosResult<()> {
         let name = CString::new(name)?;
         unsafe {
-            let ret_code = rbd_remove(ioctx, name.as_ptr());
+            let ret_code = rbd_remove(ioctx.ioctx, name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -222,11 +225,11 @@ impl Rbd {
     }
 
     ///Rename an RBD image.
-    pub fn rename(self, ioctx: rados_ioctx_t, src: &str, dst: &str) -> RadosResult<()> {
+    pub fn rename(self, ioctx: &IoCtx, src: &str, dst: &str) -> RadosResult<()> {
         let src = CString::new(src)?;
         let dst = CString::new(dst)?;
         unsafe {
-            let ret_code = rbd_rename(ioctx, src.as_ptr(), dst.as_ptr());
+            let ret_code = rbd_rename(ioctx.ioctx, src.as_ptr(), dst.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -234,10 +237,10 @@ impl Rbd {
         Ok(())
     }
     ///Get pool mirror mode.
-    pub fn mirror_mode_get(self, ioctx: rados_ioctx_t) -> RadosResult<rbd_mirror_mode_t> {
+    pub fn mirror_mode_get(self, ioctx: &IoCtx) -> RadosResult<rbd_mirror_mode_t> {
         let mut mode = rbd_mirror_mode_t_RBD_MIRROR_MODE_DISABLED;
         unsafe {
-            let ret_code = rbd_mirror_mode_get(ioctx, &mut mode);
+            let ret_code = rbd_mirror_mode_get(ioctx.ioctx, &mut mode);
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -247,13 +250,9 @@ impl Rbd {
     }
 
     ///Set pool mirror mode.
-    pub fn mirror_mode_set(
-        self,
-        ioctx: rados_ioctx_t,
-        mirror_mode: rbd_mirror_mode_t,
-    ) -> RadosResult<()> {
+    pub fn mirror_mode_set(self, ioctx: &IoCtx, mirror_mode: rbd_mirror_mode_t) -> RadosResult<()> {
         unsafe {
-            let ret_code = rbd_mirror_mode_set(ioctx, mirror_mode);
+            let ret_code = rbd_mirror_mode_set(ioctx.ioctx, mirror_mode);
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -264,7 +263,7 @@ impl Rbd {
     ///Add mirror peer.
     pub fn mirror_peer_add(
         self,
-        ioctx: rados_ioctx_t,
+        ioctx: &IoCtx,
         cluster_name: &str,
         client_name: &str,
     ) -> RadosResult<String> {
@@ -274,7 +273,7 @@ impl Rbd {
         let mut uuid: Vec<i8> = Vec::with_capacity(512);
         unsafe {
             let ret_code = rbd_mirror_peer_add(
-                ioctx,
+                ioctx.ioctx,
                 uuid.as_mut_ptr(),
                 uuid.capacity(),
                 cluster_name.as_ptr(),
@@ -289,10 +288,10 @@ impl Rbd {
     }
 
     ///Remove mirror peer.
-    pub fn mirror_peer_remove(self, ioctx: rados_ioctx_t, uuid: &str) -> RadosResult<()> {
+    pub fn mirror_peer_remove(self, ioctx: &IoCtx, uuid: &str) -> RadosResult<()> {
         let uuid = CString::new(uuid)?;
         unsafe {
-            let ret_code = rbd_mirror_peer_remove(ioctx, uuid.as_ptr());
+            let ret_code = rbd_mirror_peer_remove(ioctx.ioctx, uuid.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -303,14 +302,15 @@ impl Rbd {
     /// Set mirror peer client name
     pub fn mirror_peer_set_client(
         self,
-        ioctx: rados_ioctx_t,
+        ioctx: &IoCtx,
         uuid: &str,
         client_name: &str,
     ) -> RadosResult<()> {
         let uuid = CString::new(uuid)?;
         let client_name = CString::new(client_name)?;
         unsafe {
-            let ret_code = rbd_mirror_peer_set_client(ioctx, uuid.as_ptr(), client_name.as_ptr());
+            let ret_code =
+                rbd_mirror_peer_set_client(ioctx.ioctx, uuid.as_ptr(), client_name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -321,14 +321,15 @@ impl Rbd {
     /// Set mirror peer cluster name
     pub fn mirror_peer_set_cluster(
         self,
-        ioctx: rados_ioctx_t,
+        ioctx: &IoCtx,
         uuid: &str,
         cluster_name: &str,
     ) -> RadosResult<()> {
         let uuid = CString::new(uuid)?;
         let cluster_name = CString::new(cluster_name)?;
         unsafe {
-            let ret_code = rbd_mirror_peer_set_cluster(ioctx, uuid.as_ptr(), cluster_name.as_ptr());
+            let ret_code =
+                rbd_mirror_peer_set_cluster(ioctx.ioctx, uuid.as_ptr(), cluster_name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -338,7 +339,7 @@ impl Rbd {
 
     /// Get mirror image status summary of a pool.
     /*
-    pub fn mirror_image_status_summary(self, ioctx: rados_ioctx_t) -> RadosResult<()> {
+    pub fn mirror_image_status_summary(self, ioctx: &IoCtx) -> RadosResult<()> {
         let mut states = rbd_mirror_image_status_state_t::MIRROR_IMAGE_STATUS_STATE_UNKNOWN;
         let mut counts = 0;
         let mut maxlen = 32;
@@ -406,12 +407,12 @@ impl Rbd {
     }
 
     */
-    pub fn list(&self, ioctx: rados_ioctx_t) -> RadosResult<Vec<String>> {
+    pub fn list(&self, ioctx: &IoCtx) -> RadosResult<Vec<String>> {
         let mut name_buff: Vec<i8> = Vec::with_capacity(1024);
         let mut name_size: usize = name_buff.capacity();
         loop {
             unsafe {
-                let retcode = rbd_list(ioctx, name_buff.as_mut_ptr(), &mut name_size);
+                let retcode = rbd_list(ioctx.ioctx, name_buff.as_mut_ptr(), &mut name_size);
                 if retcode == -(nix::errno::Errno::ERANGE as i32) {
                     // provided byte array is smaller than listing size
                     trace!("Resizing to {}", name_size + 1);
@@ -465,16 +466,16 @@ impl Rbd {
 
 pub fn clone(){
 unsafe{
- rbd_clone(rados_ioctx_t p_ioctx, const char *p_name,
-	                   const char *p_snapname, rados_ioctx_t c_ioctx,
+ rbd_clone(&IoCtx p_ioctx, const char *p_name,
+	                   const char *p_snapname, &IoCtx c_ioctx,
 	                   const char *c_name, uint64_t features, int *c_order);
                        }
  }                       
 
  pub fn clone2(){
                        unsafe{
- rbd_clone2(rados_ioctx_t p_ioctx, const char *p_name,
-	                    const char *p_snapname, rados_ioctx_t c_ioctx,
+ rbd_clone2(&IoCtx p_ioctx, const char *p_name,
+	                    const char *p_snapname, &IoCtx c_ioctx,
 	                    const char *c_name, uint64_t features, int *c_order,
 	                    uint64_t stripe_unit, int stripe_count);
                         }
@@ -482,21 +483,21 @@ unsafe{
 
  pub fn clone3(){
                         unsafe{
- rbd_clone3(rados_ioctx_t p_ioctx, const char *p_name,
-	                    const char *p_snapname, rados_ioctx_t c_ioctx,
+ rbd_clone3(&IoCtx p_ioctx, const char *p_name,
+	                    const char *p_snapname, &IoCtx c_ioctx,
 	                    const char *c_name, rbd_image_options_t c_opts);
                         }
  }                        
 
  pub fn remote(){
     unsafe{
-        rbd_remove(rados_ioctx_t io, const char *name);
+        rbd_remove(&IoCtx io, const char *name);
     }
  } 
  
 pub fn remove_with_progress(){
     unsafe{
-    rbd_remove_with_progress(rados_ioctx_t io, const char *name,
+    rbd_remove_with_progress(&IoCtx io, const char *name,
                                 librbd_progress_fn_t cb,
                                             void *cbdata);
                                             }
@@ -504,7 +505,7 @@ pub fn remove_with_progress(){
 
  pub fn mirror_peer_list(){
                                         unsafe{
- rbd_mirror_peer_list(rados_ioctx_t io_ctx,
+ rbd_mirror_peer_list(&IoCtx io_ctx,
                                       rbd_mirror_peer_t *peers, int *max_peers);
                                       }
  }                                      
@@ -518,7 +519,7 @@ pub fn remove_with_progress(){
 
  pub fn mirror_image_status_list(){
                                              unsafe{
- rbd_mirror_image_status_list(rados_ioctx_t io_ctx,
+ rbd_mirror_image_status_list(&IoCtx io_ctx,
 					      const char *start_id, size_t max,
 					      char **image_ids,
 					      rbd_mirror_image_status_t *images,
@@ -535,7 +536,7 @@ pub fn remove_with_progress(){
 
  pub fn mirror_image_status_summary(){
     unsafe{
- rbd_mirror_image_status_summary(rados_ioctx_t io_ctx,
+ rbd_mirror_image_status_summary(&IoCtx io_ctx,
     rbd_mirror_image_status_state_t *states, int *counts, size_t *maxlen);
     }
  }    
@@ -544,13 +545,13 @@ pub fn remove_with_progress(){
 
 impl<'a> RbdImage<'a> {
     /// ioctx can be acquired using the ceph-rust crate
-    pub fn open(ioctx: rados_ioctx_t, name: &str, snap_name: &str) -> RadosResult<Self> {
+    pub fn open(ioctx: &IoCtx, name: &str, snap_name: &str) -> RadosResult<Self> {
         let name = CString::new(name)?;
         let snap_name = CString::new(snap_name)?;
         let mut rbd: rbd_image_t = ptr::null_mut();
 
         unsafe {
-            let ret_code = rbd_open(ioctx, name.as_ptr(), &mut rbd, snap_name.as_ptr());
+            let ret_code = rbd_open(ioctx.ioctx, name.as_ptr(), &mut rbd, snap_name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -564,21 +565,21 @@ impl<'a> RbdImage<'a> {
     /*
 pub fn open_by_id(){
                           unsafe{
- rbd_open_by_id(rados_ioctx_t io, const char *id,
+ rbd_open_by_id(&IoCtx io, const char *id,
                                 rbd_image_t *image, const char *snap_name);
                                 }
  }                                
 
 pub fn aio_open(){
 unsafe{
- rbd_aio_open(rados_ioctx_t io, const char *name,
+ rbd_aio_open(&IoCtx io, const char *name,
 			      rbd_image_t *image, const char *snap_name,
 			      rbd_completion_t c);
                   }
  }                  
 pub fn aio_open_by_id(){
                   unsafe{
- rbd_aio_open_by_id(rados_ioctx_t io, const char *id,
+ rbd_aio_open_by_id(&IoCtx io, const char *id,
                                     rbd_image_t *image, const char *snap_name,
                                     rbd_completion_t c);
                                     }
@@ -594,13 +595,14 @@ pub fn aio_open_by_id(){
     /// Attempting to write to a read-only image will return -EROFS.
     /// Open an image in read-only mode.
     /// ioctx can be acquired using the ceph-rust crate
-    pub fn open_read_only(ioctx: rados_ioctx_t, name: &str, snap_name: &str) -> RadosResult<Self> {
+    pub fn open_read_only(ioctx: &IoCtx, name: &str, snap_name: &str) -> RadosResult<Self> {
         let name = CString::new(name)?;
         let snap_name = CString::new(snap_name)?;
         let mut rbd: rbd_image_t = ptr::null_mut();
 
         unsafe {
-            let ret_code = rbd_open_read_only(ioctx, name.as_ptr(), &mut rbd, snap_name.as_ptr());
+            let ret_code =
+                rbd_open_read_only(ioctx.ioctx, name.as_ptr(), &mut rbd, snap_name.as_ptr());
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -614,14 +616,14 @@ pub fn aio_open_by_id(){
     /**
 pub fn open_by_id_read_only(){
                                     unsafe{
- rbd_open_by_id_read_only(rados_ioctx_t io, const char *id,
+ rbd_open_by_id_read_only(&IoCtx io, const char *id,
                                           rbd_image_t *image, const char *snap_name);
                                           }
  }                                          
 
 pub fn aio_open_read_open(){
                                           unsafe{
- rbd_aio_open_read_only(rados_ioctx_t io, const char *name,
+ rbd_aio_open_read_only(&IoCtx io, const char *name,
 					rbd_image_t *image, const char *snap_name,
 					rbd_completion_t c);
                     }
@@ -629,7 +631,7 @@ pub fn aio_open_read_open(){
 
 pub fn aio_open_by_id_read_open(){
                     unsafe{
- rbd_aio_open_by_id_read_only(rados_ioctx_t io, const char *id,
+ rbd_aio_open_by_id_read_only(&IoCtx io, const char *id,
                                               rbd_image_t *image, const char *snap_name,
                                               rbd_completion_t c);
                                               }
@@ -836,7 +838,7 @@ pub fn resize2(){
     /// Copy the image to another location.
     pub fn copy(
         &self,
-        dest_ioctx: rados_ioctx_t,
+        dest_ioctx: &IoCtx,
         dest_name: &str,
         features: Option<u64>,
         order: Option<u64>,
@@ -888,7 +890,7 @@ pub fn resize2(){
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
-            let ret_code = rbd_copy3(self.image, dest_ioctx, dest_name.as_ptr(), opts);
+            let ret_code = rbd_copy3(self.image, dest_ioctx.ioctx, dest_name.as_ptr(), opts);
             if ret_code < 0 {
                 return Err(RadosError::new(get_error(ret_code)?));
             }
@@ -1362,7 +1364,7 @@ pub fn lock_get_owners_cleanup(){
 
  pub fn copy_with_progress(){
  unsafe{
- rbd_copy_with_progress(rbd_image_t image, rados_ioctx_t dest_p,
+ rbd_copy_with_progress(rbd_image_t image, &IoCtx dest_p,
                                         const char *destname,
                                         librbd_progress_fn_t cb, void *cbdata);
                                          }
@@ -1378,7 +1380,7 @@ pub fn lock_get_owners_cleanup(){
  pub fn copy_with_progress3(){
  unsafe{
  rbd_copy_with_progress3(rbd_image_t image,
-					 rados_ioctx_t dest_p,
+					 &IoCtx dest_p,
 					 const char *destname,
 					 rbd_image_options_t dest_opts,
 					 librbd_progress_fn_t cb, void *cbdata);
@@ -1388,7 +1390,7 @@ pub fn lock_get_owners_cleanup(){
  pub fn copy_with_progress4(){
  unsafe{
  rbd_copy_with_progress4(rbd_image_t image,
-					 rados_ioctx_t dest_p,
+					 &IoCtx dest_p,
 					 const char *destname,
 					 rbd_image_options_t dest_opts,
 					 librbd_progress_fn_t cb, void *cbdata,
@@ -1399,7 +1401,7 @@ pub fn lock_get_owners_cleanup(){
 /* deep copy */
 pub fn deep_copy(){
  unsafe{
- rbd_deep_copy(rbd_image_t src, rados_ioctx_t dest_io_ctx,
+ rbd_deep_copy(rbd_image_t src, &IoCtx dest_io_ctx,
                                const char *destname,
                                rbd_image_options_t dest_opts);
                                 }
@@ -1408,7 +1410,7 @@ pub fn deep_copy(){
 pub fn deep_copy_with_progress(){
  unsafe{
  rbd_deep_copy_with_progress(rbd_image_t image,
-                                             rados_ioctx_t dest_io_ctx,
+                                             &IoCtx dest_io_ctx,
                                              const char *destname,
                                              rbd_image_options_t dest_opts,
                                              librbd_progress_fn_t cb,


### PR DESCRIPTION
I added a PhantomData marker to tell the compiler that IoCtx needs to outlive our RbdImage pointer.  Testing with 10 threads and valgrind seems to show that this works in practice.  I don't know if it'll work in every situation though.  The related PR for this is here: https://github.com/ceph/ceph-rust/pull/33