### PR TITLE
Update the Ceph Crate Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.3.2"
 bindgen = "0.47.1"
 
 [dependencies]
-ceph = "~2.0"
+ceph = "~3"
 libc = "~0.2"
 log = "~0.4"
 nix = "~0.10"

--- a/src/rbd.rs
+++ b/src/rbd.rs
@@ -708,14 +708,14 @@ pub fn resize2(){
         }
         let name_prefix_vec: Vec<u8> = info
             .block_name_prefix
-            .into_iter()
+            .iter()
             .map(|c| c.clone() as u8)
             .filter(|c| c > &0)
             .collect();
         let name_prefix = String::from_utf8(name_prefix_vec)?;
         let parent_name_vec: Vec<u8> = info
             .parent_name
-            .into_iter()
+            .iter()
             .map(|c| c.clone() as u8)
             .filter(|c| c > &0)
             .collect();


### PR DESCRIPTION
update the ceph crate version and change into_iter() to iter() to avoid deprecated behavior